### PR TITLE
Update MaxCDN Link To Version 3.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The Form Plugin supports use of [XMLHttpRequest Level 2]("http://www.w3.org/TR/X
 ---
 
 ##CDN Support
-`<script src="//oss.maxcdn.com/jquery.form/3.50/jquery.form.min.js"></script>`
+`<script src="//oss.maxcdn.com/jquery.form/3.51/jquery.form.min.js"></script>`
 
 ##Copyright and License
 Copyright 2006-2013 (c) M. Alsup


### PR DESCRIPTION
The link was previously pointing to 3.50 instead of 3.51